### PR TITLE
Remove static typing for python 2.7

### DIFF
--- a/celery_cloudwatch/monitor.py
+++ b/celery_cloudwatch/monitor.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 SEQUENCE_TOKENS = {}
 
 
-def get_sequence_token(cloudwatch, log_group: str, log_stream: str):
+def get_sequence_token(cloudwatch, log_group, log_stream):
     """Gets the next sequence token to use for uploading
     a log even to CloudWatch.
 
@@ -50,7 +50,7 @@ def get_sequence_token(cloudwatch, log_group: str, log_stream: str):
     return token
 
 
-def get_timestamp_utc() -> int:
+def get_timestamp_utc():
     """Gets the current date/time in UTC neutral
     timestamp, formatted as the amount of milliseconds
     that passed since January 1, 1970 (unix epoch).


### PR DESCRIPTION
Static typing only exists in python 3, so we're going to make it
backwards-compatible.

ticket: RM-900